### PR TITLE
修复build.gradle 中依赖版本较旧及库中依赖的冲突导致的无法编译问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,13 +247,18 @@ repositories {
     }
     maven {
         name = 'mali'
-        url = "https://raw.github.com/MegumiKasuga/kasuga-maven/mali/"
+        url = "https://raw.github.com/MegumiKasuga/kasuga-maven/mali_1.1.0/"
     }
 
     mavenLocal()
     flatDir {
         dir('libs')
     }
+}
+
+configurations.all {
+    // 只排除 javax.annotation-api
+    exclude group: 'javax.annotation', module: 'javax.annotation-api'
 }
 
 dependencies {
@@ -312,9 +317,13 @@ dependencies {
         exclude group: 'io.netty', module: 'netty-common';
     }
 
-    minecraftLibrary "edu.carole:Mixed-Arithmetic-Logic-Interpreter:1.0.0"
+    minecraftLibrary ("edu.carole:Mixed-Arithmetic-Logic-Interpreter:1.1.0") {
+        exclude group: 'com.google.guava', module: 'guava';
+        exclude group: 'com.google.code.gson', module: 'gson';
+    }
     shadedLib(group: "edu.carole", name: "Mixed-Arithmetic-Logic-Interpreter", version: "[1.0.0, 2.0.0)") {
-        exclude group: 'com.ibm.icu', module: 'icu4j'
+        exclude group: 'com.google.guava', module: 'guava';
+        exclude group: 'com.google.code.gson', module: 'gson';
     }
 
     // shadedLib("org.graalvm.polyglot:js-community:23.1.0");
@@ -360,8 +369,8 @@ dependencies {
     // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api") // Adds JEI API as a compile dependency
     // runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency
     // implementation fg.deobf("com.tterrag.registrate:Registrate:MC${minecraft_version}-${registrate_version}") // Adds registrate as a dependency
-    minecraftLibrary "edu.carole:Mixed-Arithmetic-Logic-Interpreter:1.0.2"
-    shadedLib (group: "edu.carole", name: "Mixed-Arithmetic-Logic-Interpreter", version: "[1.0.0, 2.0.0)")
+    // minecraftLibrary "edu.carole:Mixed-Arithmetic-Logic-Interpreter:1.0.2"
+    // shadedLib (group: "edu.carole", name: "Mixed-Arithmetic-Logic-Interpreter", version: "[1.0.0, 2.0.0)")
     // Examples using mod jars from ./libs
     // implementation fg.deobf("blank:coolmod-${minecraft_version}:${coolmod_version}")
     minecraftLibrary("io.javalin:javalin:6.6.0"){


### PR DESCRIPTION
 - change maven repo address of 'mali'
 - change dependenies edu.carole:Mixed-Arithmetic-Logic-Interpreter version from 1.0.0 to 1.1.0
 - exclude Mixed-Arithmetic-Logic-Interpreter dependenies:  'com.google.guava' and 'com.google.code.gson' to prevent dependency conflict